### PR TITLE
Pase a Develop - Agregada nueva función de Traducción de un ítem (todos/translate.py).

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,6 +19,20 @@ provider:
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
       Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/${self:provider.environment.DYNAMODB_TABLE}"
+    
+    - Effect: Allow
+      Action:
+        - translate:TranslateText
+        - translate:GetTerminology
+        - translate:ListTerminologies
+        - translate:ListTextTranslationJobs
+        - translate:DescribeTextTranslationJob
+        - translate:GetParallelData
+        - translate:ListParallelData
+        - comprehend:DetectDominantLanguage
+        - cloudwatch:GetMetricStatistics
+        - cloudwatch:ListMetrics
+      Resource: "*"
 
 functions:
   create:
@@ -59,6 +73,14 @@ functions:
       - http:
           path: todos/{id}
           method: delete
+          cors: true
+
+  translate:
+    handler: todos/translate.translate
+    events:
+      - http:
+          path: todos/{id}/{language}
+          method: get
           cors: true
 
 resources:

--- a/todos/translate.py
+++ b/todos/translate.py
@@ -1,0 +1,32 @@
+import os
+import json
+
+from todos import decimalencoder
+import boto3
+dynamodb = boto3.resource('dynamodb')
+traductor = boto3.client('translate')
+
+def translate(event, context):
+    table = dynamodb.Table(os.environ['DYNAMODB_TABLE'])
+
+    # fetch todo from the database
+    result = table.get_item(
+        Key={
+            'id': event['pathParameters']['id']
+        }
+    )
+
+    source_language = 'auto' # Dejamos que Amazon Comprehend detecte el lenguaje origen
+    target_language = event['pathParameters']['language']
+
+    result_trad = traductor.translate_text(Text=result['Item'].get('text'), SourceLanguageCode=source_language, TargetLanguageCode=target_language)
+
+    # create a response
+    response = {
+        "statusCode": 200,
+        "body": json.dumps(result_trad.get('TranslatedText'),
+                           cls=decimalencoder.DecimalEncoder)
+    }
+
+    return response
+


### PR DESCRIPTION
Se detecta el lenguaje origen automaticamente con Amazon Comprehend y se traduce al lenguaje
indicado por un codigo 'en', 'de', 'fr' indicado en la url de la solicitud a la API.

También se agrega una politica al rol IAM de Lambda para que así tenga permiso de llamar a las funciones Translate() de Lambda.

Ejemplo de Uso:
https://441thgk2he.execute-api.us-east-1.amazonaws.com/dev/todos/a28d755c-b596-11eb-a464-1545f8b590f1
Retorna: text  "Lambda es un lenguaje increible."

https://441thgk2he.execute-api.us-east-1.amazonaws.com/dev/todos/a28d755c-b596-11eb-a464-1545f8b590f1/en
Retorna: "Lambda is an amazing language."

https://441thgk2he.execute-api.us-east-1.amazonaws.com/dev/todos/a28d755c-b596-11eb-a464-1545f8b590f1/fr
Retorna: "Le lambda est une langue étonnante."
